### PR TITLE
The resource path's prefix must be slash while generate the authorization

### DIFF
--- a/src/main/java/com/qcloud/cos/auth/COSSigner.java
+++ b/src/main/java/com/qcloud/cos/auth/COSSigner.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.qcloud.cos.utils.StringUtils;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.codec.digest.HmacUtils;
 
@@ -67,6 +68,15 @@ public class COSSigner {
                 new HashMap<String, String>(), cred, expiredTime);
     }
 
+    private String prefixMustBeSlash(String picturePath) {
+        if (StringUtils.isNullOrEmpty(picturePath)) {
+            picturePath = "/";
+        } else if (!picturePath.startsWith("/")) {
+            picturePath = "/" + picturePath;
+        }
+        return picturePath;
+    }
+
     public String buildAuthorizationStr(HttpMethodName methodName, String resouce_path,
             Map<String, String> headerMap, Map<String, String> paramMap, COSCredentials cred,
             Date expiredTime) {
@@ -74,6 +84,8 @@ public class COSSigner {
         if (isAnonymous(cred)) {
             return null;
         }
+
+        resouce_path = prefixMustBeSlash(resouce_path);
 
         Map<String, String> signHeaders = buildSignHeaders(headerMap);
         // 签名中的参数和http 头部 都要进行字符串排序


### PR DESCRIPTION
### 使用场景：
* 后端利用`cos-java-sdk-v5`中的`CosSigner.buildAuthorizationStr`方法提供一个 `generateAuthorization(resourcePath, httpMethod) ` API 生成 COS 上某资源的 `authorization`；
* 前端利用`cos-js-sdk-v5`里的`CosCloud.sliceUploadFile`去后端拿这个`authorization`然后做图片上传。

### 遇到的问题：
```
<Error>
    <Code>SignatureDoesNotMatch</Code>
    <Message>The Signature you specified is invalid.</Message>
    ...
</Error>
```

### 分析：
`cos-js-sdk-v5`自身提供的签名算法是可以正常工作的，对比`cos-js-sdk-v5`中的算法，比较特别的是：
```javascript
var pathname = opt.pathname || opt.Key || '/';
...
pathname.indexOf('/') !== 0 && (pathname = '/' + pathname);
```

### 结论
`resource_path`是`/`或者以 `/`开头的字符串，生成出来的签名才是有效的。

