### PR TITLE
exception_support_return_header

### DIFF
--- a/src/main/java/com/qcloud/cos/exception/CosServiceException.java
+++ b/src/main/java/com/qcloud/cos/exception/CosServiceException.java
@@ -18,6 +18,7 @@
 
 package com.qcloud.cos.exception;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -101,6 +102,11 @@ public class CosServiceException extends CosClientException {
      * Additional information on the exception.
      */
     private Map<String, String> additionalDetails;
+
+    /**
+     * header information
+     */
+    private Map<String, String> headers = new HashMap<String, String>();
 
     /**
      * Returns the error XML received in the HTTP Response or null if the exception is constructed
@@ -288,6 +294,14 @@ public class CosServiceException extends CosClientException {
      */
     public void setRawResponseContent(String rawResponseContent) {
         this.rawResponseContent = rawResponseContent;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
     }
 
 }

--- a/src/main/java/com/qcloud/cos/exception/CosServiceExceptionBuilder.java
+++ b/src/main/java/com/qcloud/cos/exception/CosServiceExceptionBuilder.java
@@ -57,6 +57,11 @@ public class CosServiceExceptionBuilder {
     private Map<String, String> additionalDetails;
 
     /**
+     * header information
+     */
+    private Map<String, String> headers = new HashMap<String, String>();
+
+    /**
      * Returns the error XML received in the HTTP Response or null if the exception is constructed
      * from the headers.
      */
@@ -185,6 +190,7 @@ public class CosServiceExceptionBuilder {
         cosException.setRequestId(requestId);
         cosException.setAdditionalDetails(additionalDetails);
         cosException.setErrorType(errorTypeOf(statusCode));
+        cosException.setHeaders(headers);
         return cosException;
     }
 
@@ -198,4 +204,13 @@ public class CosServiceExceptionBuilder {
     private ErrorType errorTypeOf(int statusCode) {
         return statusCode >= 500 ? ErrorType.Service : ErrorType.Client;
     }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
 }

--- a/src/main/java/com/qcloud/cos/internal/CosErrorResponseHandler.java
+++ b/src/main/java/com/qcloud/cos/internal/CosErrorResponseHandler.java
@@ -101,6 +101,7 @@ public class CosErrorResponseHandler implements HttpResponseHandler<CosServiceEx
              */
             int targetDepth = 0;
             final CosServiceExceptionBuilder exceptionBuilder = new CosServiceExceptionBuilder();
+            exceptionBuilder.setHeaders(httpResponse.getHeaders());
             exceptionBuilder.setErrorResponseXml(content);
             exceptionBuilder.setStatusCode(httpResponse.getStatusCode());
 


### PR DESCRIPTION
exception_support_return_header
1. use for like append when the position error， return the true position，but the response do not contain the infomation