### PR TITLE
refine complete multipart upload retry

### DIFF
--- a/src/main/java/com/qcloud/cos/internal/XmlResponsesSaxParser.java
+++ b/src/main/java/com/qcloud/cos/internal/XmlResponsesSaxParser.java
@@ -18,6 +18,19 @@
 
 package com.qcloud.cos.internal;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 import com.qcloud.cos.exception.CosClientException;
 import com.qcloud.cos.exception.CosServiceException;
 import com.qcloud.cos.exception.MultiObjectDeleteException.DeleteError;
@@ -63,11 +76,11 @@ import com.qcloud.cos.model.ReplicationDestinationConfig;
 import com.qcloud.cos.model.ReplicationRule;
 import com.qcloud.cos.model.RoutingRule;
 import com.qcloud.cos.model.RoutingRuleCondition;
-import com.qcloud.cos.model.Tag.LifecycleTagPredicate;
-import com.qcloud.cos.model.Tag.Tag;
 import com.qcloud.cos.model.TagSet;
 import com.qcloud.cos.model.UinGrantee;
 import com.qcloud.cos.model.VersionListing;
+import com.qcloud.cos.model.Tag.LifecycleTagPredicate;
+import com.qcloud.cos.model.Tag.Tag;
 import com.qcloud.cos.model.ciModel.auditing.AudioAuditingResponse;
 import com.qcloud.cos.model.ciModel.auditing.AuditingJobsDetail;
 import com.qcloud.cos.model.ciModel.auditing.AudtingCommonInfo;
@@ -166,6 +179,7 @@ import com.qcloud.cos.model.lifecycle.LifecyclePrefixPredicate;
 import com.qcloud.cos.utils.DateUtils;
 import com.qcloud.cos.utils.StringUtils;
 import com.qcloud.cos.utils.UrlEncoderUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
@@ -174,19 +188,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xml.sax.helpers.XMLReaderFactory;
-
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 
 /**
  * XML Sax parser to read XML documents returned by COS via the REST interface, converting these
@@ -1905,6 +1906,10 @@ public class XmlResponsesSaxParser {
             return result;
         }
 
+        public void setCOSException(CosServiceException e) {
+            cse = e;
+        }
+
         public CosServiceException getCOSException() {
             return cse;
         }
@@ -1957,6 +1962,8 @@ public class XmlResponsesSaxParser {
                     errorCode = getText();
                 } else if (name.equals("Message")) {
                     cse = new CosServiceException(getText());
+                    // complete multipart upload return 200 and chunked body
+                    cse.setStatusCode(200);
                 } else if (name.equals("RequestId")) {
                     requestId = getText();
                 } else if (name.equals("HostId")) {


### PR DESCRIPTION
1. 对于 complete multipart upload 返回 200 又报 Internal Error 的请求进行重试；
2. 如果重试遇到 404 NoSuchUpload 要判断是否文件已经完成合并（通过 head 一下，如果之前文件是已经存在的，会直接返回合并成功，这里有一个场景是：重试之前，upload 被 abort 了，重试却会返回合并成功，没有好的办法.. 但是出现的可能非常小，评估下这里的影响）；
3. CI complete multipart upload 重试碰到 404 NoSuchUpload 没法重组 CiResult，所以不进行重试；