### PR TITLE
support to set KMS Server endpoint when use client-side-encryption

### DIFF
--- a/src/main/java/com/qcloud/cos/demo/KMSEncryptionClientDemo.java
+++ b/src/main/java/com/qcloud/cos/demo/KMSEncryptionClientDemo.java
@@ -28,6 +28,8 @@ import com.qcloud.cos.transfer.Download;
 import com.qcloud.cos.transfer.TransferManager;
 import com.qcloud.cos.transfer.TransferManagerConfiguration;
 import com.qcloud.cos.transfer.Upload;
+import com.tencentcloudapi.common.profile.ClientProfile;
+import com.tencentcloudapi.common.profile.HttpProfile;
 
 public class KMSEncryptionClientDemo {
 	static String cmk = "kms-xxxxxxx";
@@ -67,6 +69,22 @@ public class KMSEncryptionClientDemo {
 
         // 生成加密客户端EncryptionClient, COSEncryptionClient是COSClient的子类, 所有COSClient支持的接口他都支持。
         // EncryptionClient覆盖了COSClient上传下载逻辑，操作内部会执行加密操作，其他操作执行逻辑和COSClient一致
+
+        // in case you want to use different kms server:
+        //{
+        //String kmsEndPoint = "";
+        ///HttpProfile httpProfile = new HttpProfile();
+        //httpProfile.setEndpoint(kmsEndPoint);
+        //httpProfile.setProtocol(HttpProfile.REQ_HTTP);
+        //ClientProfile clientProfile = new ClientProfile();
+        //clientProfile.setHttpProfile(httpProfile);
+
+        //COSEncryptionClient cosEncryptionClient =
+        //        new COSEncryptionClient(new COSStaticCredentialsProvider(cred),
+        //                new KMSEncryptionMaterialsProvider(encryptionMaterials), clientConfig,
+        //                cryptoConf,clientProfile);
+        //}
+        
         COSEncryptionClient cosEncryptionClient =
                 new COSEncryptionClient(new COSStaticCredentialsProvider(cred),
                         new KMSEncryptionMaterialsProvider(encryptionMaterials), clientConfig,

--- a/src/main/java/com/qcloud/cos/internal/crypto/TencentCloudKMSClient.java
+++ b/src/main/java/com/qcloud/cos/internal/crypto/TencentCloudKMSClient.java
@@ -29,6 +29,7 @@ import com.tencentcloudapi.kms.v20190118.models.EncryptRequest;
 import com.tencentcloudapi.kms.v20190118.models.EncryptResponse;
 import com.tencentcloudapi.kms.v20190118.models.GenerateDataKeyRequest;
 import com.tencentcloudapi.kms.v20190118.models.GenerateDataKeyResponse;
+import com.tencentcloudapi.common.profile.ClientProfile;
 
 /**
  * Client for accessing TencentCloud KMS.
@@ -45,6 +46,14 @@ public class TencentCloudKMSClient implements QCLOUDKMS {
         this.kmsClient = new KmsClient(credential, region);
     } 
 
+    public TencentCloudKMSClient(COSCredentialsProvider cosCredentialsProvider, String region, ClientProfile clientProfile) {
+        COSCredentials cosCredentials = cosCredentialsProvider.getCredentials();
+        String secretId = cosCredentials.getCOSAccessKeyId();
+        String secretKey = cosCredentials.getCOSSecretKey();
+
+        Credential credential = new Credential(secretId, secretKey);
+        this.kmsClient = new KmsClient(credential, region, clientProfile);
+    }
     /**
      * Generates a unique symmetric data key for client-side encryption. This operation returns a plaintext copy of the
      * data key and a copy that is encrypted under a customer master key (CMK) that you specify. You can use the


### PR DESCRIPTION
在测试TCE下kms托管的客户端加密功能时，发现sdk没有指定kms服务器的endpoint的配置接口，而是固定了公有云kms服务器地址。因此增加一个构造函数，可以配置kms服务器地址。
使用方法示例：
```java
      {
      String kmsEndPoint = "";
      HttpProfile httpProfile = new HttpProfile();
      httpProfile.setEndpoint(kmsEndPoint);
      httpProfile.setProtocol(HttpProfile.REQ_HTTP);
      ClientProfile clientProfile = new ClientProfile();
      clientProfile.setHttpProfile(httpProfile);

      COSEncryptionClient cosEncryptionClient =
              new COSEncryptionClient(new COSStaticCredentialsProvider(cred),
                      new KMSEncryptionMaterialsProvider(encryptionMaterials), clientConfig,
                      cryptoConf,clientProfile);
      }

```